### PR TITLE
Fix: Create a shallow copy of loop packet

### DIFF
--- a/src/weewx_ha/controller.py
+++ b/src/weewx_ha/controller.py
@@ -202,7 +202,7 @@ class Controller(StdService):
         logger.debug("Received WeeWX loop packet")
         if self.mqtt_client.is_connected():
             preprocessor_future = self.executor.submit(
-                self.packet_preprocessor.process_packet, event.packet
+                self.packet_preprocessor.process_packet, event.packet.copy()
             )
             preprocessor_future.add_done_callback(self.preprocessor_complete)
         else:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Create a shallow copy of the loop packet instance before sending it to preprocessor.

This fixes a race condition bug that ocurred when [weewx-home-assistant](https://github.com/felddy/weewx-home-assistant) was combined with [weewx-mqtt](https://github.com/matthewwall/weewx-mqtt).

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

After installing [weewx-home-assistant](https://github.com/felddy/weewx-home-assistant) extension, I noticed that [weewx-mqtt](https://github.com/matthewwall/weewx-mqtt) extension would occasionally crash with this stacktrace:

```
CRITICAL MQTT: Thread terminating. Reason: dictionary changed size during iteration
Exception in thread MQTT:
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.12/site-packages/weewx/restx.py", line 359, in run
    self.run_loop()
  File "/usr/local/lib/python3.12/site-packages/weewx/restx.py", line 384, in run_loop
    self.process_record(_record, dbmanager)
  File "/etc/weewx/bin/user/mqtt.py", line 515, in process_record
    record = weewx.units.to_std_system(record, self.unit_system)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/weewx/units.py", line 1613, in to_std_system
    _datadict_target = StdUnitConverters[unit_system].convertDict(datadict)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/weewx/units.py", line 958, in convertDict
    for obs_type in obs_dict:
                    ^^^^^^^^
RuntimeError: dictionary changed size during iteration
```

This WeeWX instance had been running with [weewx-mqtt](https://github.com/matthewwall/weewx-mqtt) extension for years. This bug had never occurred before I installed [weewx-home-assistant](https://github.com/felddy/weewx-home-assistant). Now, it takes a random amount of time (from 0 to 1 hour) after the server starts for [weewx-mqtt](https://github.com/matthewwall/weewx-mqtt) to crash.

With some debugging, I found that the loop packet instance processed by [weewx-mqtt](https://github.com/matthewwall/weewx-mqtt) was being modified concurrently in another thread by [weewx-home-assistant's preprocessor](https://github.com/felddy/weewx-home-assistant/blob/develop/src/weewx_ha/preprocessor.py#L35-L36).

Creating a shallow copy of the packet as proposed in this PR should solve the issue.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

My WeeWX instance has been running with this patch for the last 3 months: both [weewx-home-assistant](https://github.com/felddy/weewx-home-assistant) and [weewx-mqtt](https://github.com/matthewwall/weewx-mqtt) seem to work normally.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
